### PR TITLE
Improve build cacheability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,7 @@ val rat by tasks.getting(org.nosphere.apache.rat.RatTask::class) {
     // Note: patterns are in non-standard syntax for RAT, so we use exclude(..) instead of excludeFile
     exclude(rootDir.resolve(".ratignore").readLines())
     exclude("src/dist-check/temp")
+    dependsOn(":src:dist:copyBinLibs", ":src:dist:copyLibs")
 }
 
 tasks.validateBeforeBuildingReleaseArtifacts {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,7 @@ val rat by tasks.getting(org.nosphere.apache.rat.RatTask::class) {
     verbose.set(true)
     // Note: patterns are in non-standard syntax for RAT, so we use exclude(..) instead of excludeFile
     exclude(rootDir.resolve(".ratignore").readLines())
+    exclude("src/dist-check/temp")
 }
 
 tasks.validateBeforeBuildingReleaseArtifacts {

--- a/buildSrc/subprojects/batchtest/src/main/kotlin/org/apache/jmeter/buildtools/batchtest/BatchTest.kt
+++ b/buildSrc/subprojects/batchtest/src/main/kotlin/org/apache/jmeter/buildtools/batchtest/BatchTest.kt
@@ -25,6 +25,7 @@ import org.eclipse.jgit.diff.RawTextComparator
 import org.eclipse.jgit.util.io.AutoCRLFInputStream
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -48,6 +49,7 @@ open class BatchTest @Inject constructor(objects: ObjectFactory) : JavaExec() {
     val testName = objects.property<String>()
 
     @InputDirectory
+    @IgnoreEmptyDirectories
     val inputDirectory = objects.directoryProperty().convention(
         project.rootProject.layout.projectDirectory.dir("bin/testfiles")
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx768m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ spotbugs.version=4.1.2
 velocity.version=1.7
 
 # Plugins
-com.github.autostyle.version=3.0
+com.github.autostyle.version=3.2
 com.github.spotbugs.version=4.5.0
 com.github.vlsi.checksum-dependency.sha512=84572B7F654D1F9842DDD7E0D4331461DC55B92CDC1DA8EBA2269870CE027B021AB91D1942043145825B00521A92029C969BFA388A27BD63CC509BF7AB18E35F
 com.github.vlsi.checksum-dependency.version=1.77

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ com.github.autostyle.version=3.2
 com.github.spotbugs.version=4.5.0
 com.github.vlsi.checksum-dependency.sha512=84572B7F654D1F9842DDD7E0D4331461DC55B92CDC1DA8EBA2269870CE027B021AB91D1942043145825B00521A92029C969BFA388A27BD63CC509BF7AB18E35F
 com.github.vlsi.checksum-dependency.version=1.77
-com.github.vlsi.vlsi-release-plugins.version=1.77
+com.github.vlsi.vlsi-release-plugins.version=1.85
 kotlin.version=1.6.21
 # Restrict uses of Kotlin APIs to 1.5 only, so projects that use Kotlin 1.5 can use JMeter
 kotlin.api.version=1.5

--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -330,14 +330,14 @@ fun createAnakiaTask(
     }
 
     return tasks.register(taskName) {
-        inputs.file("$baseDir/$style")
-        inputs.file("$baseDir/$projectFile")
+        inputs.file("$baseDir/$style").withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("styleDir")
+        inputs.file("$baseDir/$projectFile").withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("projectDir")
         inputs.files(
             fileTree(baseDir) {
                 include(*includes)
                 exclude(*excludes)
             }
-        )
+        ).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("baseDir")
         inputs.property("extension", extension)
         outputs.dir(outputDir)
         outputs.cacheIf { true }
@@ -440,7 +440,7 @@ fun xslt(
 
 val processSiteXslt by tasks.registering {
     val outputDir = "$buildDir/siteXslt"
-    inputs.files(xdocs)
+    inputs.files(xdocs).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("xdocs")
     inputs.property("year", lastEditYear)
     outputs.dir(outputDir)
     outputs.cacheIf { true }

--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -535,6 +535,7 @@ fun CrLfSpec.sourceLayout() = copySpec {
         from(rootDir) {
             gitignore(gitProps)
             excludeLicenseFromSourceRelease()
+            exclude("src/dist-check/temp")
         }
     }
 }

--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -340,6 +340,7 @@ fun createAnakiaTask(
         )
         inputs.property("extension", extension)
         outputs.dir(outputDir)
+        outputs.cacheIf { true }
         dependsOn(prepareProps)
 
         doLast {
@@ -442,6 +443,7 @@ val processSiteXslt by tasks.registering {
     inputs.files(xdocs)
     inputs.property("year", lastEditYear)
     outputs.dir(outputDir)
+    outputs.cacheIf { true }
 
     doLast {
         for (f in (outputs as TaskOutputsInternal).previousOutputFiles) {

--- a/src/licenses/build.gradle.kts
+++ b/src/licenses/build.gradle.kts
@@ -51,7 +51,7 @@ fun gradleWrapperVersion(wrapperProps: String) =
 
 val gatherSourceLicenses by tasks.registering(GatherLicenseTask::class) {
     val wrapperProps = "$rootDir/gradle/wrapper/gradle-wrapper.properties"
-    inputs.file(wrapperProps)
+    inputs.file(wrapperProps).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("wrapper.props")
     addDependency("org.gradle:gradle-wrapper:${gradleWrapperVersion(wrapperProps)}", SpdxLicense.Apache_2_0)
     addDependency(":bootstrap:3.3.4", SpdxLicense.MIT)
     addDependency(":bootstrap-social:4.8.0", SpdxLicense.MIT)


### PR DESCRIPTION
## Description
This PR addresses a number of issues in some gradle tasks:
- ignores empty directories for task inputs
- configures task dependencies
- replace relative paths with absolute paths where applicable
- enable build caching for tasks that did not support it but should

## Motivation and Context
Some gradle tasks were configured in a way that prevented incremental builds and build caching from being used effectively. This PR addresses some of these issues. 

## How Has This Been Tested?
This has been tested with the [Gradle Enterprise build validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Non-breaking improvements to the build

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
